### PR TITLE
chore: add config_specs.proto

### DIFF
--- a/protos/config_specs.proto
+++ b/protos/config_specs.proto
@@ -1,0 +1,189 @@
+syntax = "proto3";
+
+package statsig;
+
+message SpecsEnvelope {
+  SpecsEnvelopeKind kind = 1;
+  string name = 2;
+  string checksum = 3;
+  optional bytes data = 4;
+}
+
+enum SpecsEnvelopeKind {
+  SPECS_ENVELOPE_KIND_UNKNOWN = 0;
+  
+  SPECS_ENVELOPE_KIND_DONE = 1;
+  SPECS_ENVELOPE_KIND_TOP_LEVEL = 2; // SpecsTopLevel
+
+  SPECS_ENVELOPE_KIND_FEATURE_GATE = 3; // Spec
+  SPECS_ENVELOPE_KIND_DYNAMIC_CONFIG = 4; // Spec
+  SPECS_ENVELOPE_KIND_LAYER_CONFIG = 5; // Spec
+}
+
+message SpecsTopLevel {
+  bool has_updates = 1;
+  uint64 time = 2;
+  string company_id = 3;
+  string response_format = 4;
+  string checksum = 5;
+  map<string, Condition> condition_map = 6;
+  map<string, string> experiment_to_layer = 7;
+  map<string, AnyValue> sdk_configs = 8;
+  SessionReplayInfo session_replay_info = 9;
+  Diagnostics diagnostics = 10;
+}
+
+message Spec {
+  string salt = 1;
+  bool enabled = 2;
+  ReturnValue default_value = 3;
+  EntityType entity = 4;
+  IdType id_type = 5;
+  uint32 version = 6;
+  repeated Rule rules = 7;
+  optional bool is_active = 8;
+  repeated string explicit_parameters = 9;
+}
+
+message Rule {
+  string name = 1;
+  uint32 pass_percentage = 2;
+  string id = 3;
+  optional string salt = 4;
+  repeated string conditions = 5;
+  IdType id_type = 6;
+  ReturnValue return_value = 7;
+}
+
+message Condition {
+  ConditionType condition_type = 1;
+  IdType id_type = 2;
+
+  optional AnyValue target_value = 3;
+  optional Operator operator = 4;
+  optional string field = 5;
+  optional bytes additional_values = 6;
+}
+
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int64_value = 3;
+    uint64 uint64_value = 4;
+    double double_value = 5;
+    bytes raw_value = 6;
+  }
+}
+
+enum ConditionType {
+  CONDITION_TYPE_UNKNOWN = 0;
+
+  CONDITION_TYPE_PUBLIC = 1;
+  CONDITION_TYPE_FAIL_GATE = 2;
+  CONDITION_TYPE_PASS_GATE = 3;
+  CONDITION_TYPE_UA_BASED = 4;
+  CONDITION_TYPE_IP_BASED = 5;
+  CONDITION_TYPE_USER_FIELD = 6;
+  CONDITION_TYPE_ENVIRONMENT_FIELD = 7;
+  CONDITION_TYPE_CURRENT_TIME = 8;
+  CONDITION_TYPE_USER_BUCKET = 9;
+  CONDITION_TYPE_TARGET_APP = 10;
+  CONDITION_TYPE_UNIT_ID = 11;
+}
+
+enum Operator {
+  OPERATOR_UNKNOWN = 0;
+
+  OPERATOR_GT = 1;  
+  OPERATOR_GTE = 2;
+  OPERATOR_LT = 3;
+  OPERATOR_LTE = 4;
+  OPERATOR_VERSION_GT = 5;
+  OPERATOR_VERSION_GTE = 6;
+  OPERATOR_VERSION_LT = 7;
+  OPERATOR_VERSION_LTE = 8;
+  OPERATOR_VERSION_EQ = 9;
+  OPERATOR_VERSION_NEQ = 10;
+  OPERATOR_ANY = 11;
+  OPERATOR_NONE = 12;
+  OPERATOR_STR_STARTS_WITH_ANY = 13;
+  OPERATOR_STR_ENDS_WITH_ANY = 14;
+  OPERATOR_STR_CONTAINS_ANY = 15;
+  OPERATOR_STR_CONTAINS_NONE = 16;
+  OPERATOR_ANY_CASE_SENSITIVE = 17;
+  OPERATOR_NONE_CASE_SENSITIVE = 18;
+  OPERATOR_STR_MATCHES = 19;
+  OPERATOR_BEFORE = 20;
+  OPERATOR_AFTER = 21;
+  OPERATOR_ON = 22;
+  OPERATOR_EQ = 23;
+  OPERATOR_NEQ = 24;
+  OPERATOR_IN_SEGMENT_LIST = 25;
+  OPERATOR_NOT_IN_SEGMENT_LIST = 26;
+  OPERATOR_ARRAY_CONTAINS_ANY = 27;
+  OPERATOR_ARRAY_CONTAINS_NONE = 28;
+  OPERATOR_ARRAY_CONTAINS_ALL = 29;
+  OPERATOR_NOT_ARRAY_CONTAINS_ALL = 30;
+  OPERATOR_ENCODED_ANY = 31;
+}
+
+message ReturnValue {
+    oneof value {
+        bool bool_value = 1;
+        bytes raw_value = 2;
+    }
+}
+
+message IdType {
+    oneof id_type {
+        KnownIdType known_id_type = 1;
+        string custom_id_type = 2;
+    }
+}
+
+enum KnownIdType {
+    KNOWN_ID_TYPE_UNKNOWN = 0;
+
+    KNOWN_ID_TYPE_USER_ID = 1;
+    KNOWN_ID_TYPE_STABLE_ID = 2;
+}
+
+enum EntityType {
+    ENTITY_UNKNOWN = 0;
+
+    ENTITY_FEATURE_GATE = 1;
+    ENTITY_DYNAMIC_CONFIG = 2;
+    ENTITY_AUTOTUNE = 3;
+    ENTITY_EXPERIMENT = 4;
+    ENTITY_LAYER = 5;
+    ENTITY_SEGMENT = 6;
+    ENTITY_HOLDOUT = 7;
+}
+
+// ------------------------------------------------------------------------ [ Session Replay ]
+
+message SessionReplayInfo {
+  optional float sampling_rate = 1;
+  optional string targeting_gate = 2;
+  optional bool recording_blocked = 3;
+  map<string, SessionReplayTrigger> session_recording_event_triggers = 4;
+  map<string, SessionReplayTrigger> session_recording_exposure_triggers = 5;
+}
+
+message SessionReplayTrigger {
+  float sampling_rate = 1;
+  repeated string values = 2;
+}
+
+// ------------------------------------------------------------------------ [ Diagnostics ]
+
+message Diagnostics {
+  float initialize = 1;
+  float dcs = 2;
+  float download_config_specs = 3;
+  float log = 4;
+  float log_event = 5;
+  float idlist = 6;
+  float get_id_list = 7;
+}


### PR DESCRIPTION
Adds a the protobuf schema for DCS v2. See this stack: https://app.graphite.com/github/pr/statsig-io/statsig/92610/pubsub-add-telemetry-around-protobuf_specs-usage