### PR TITLE
chore: move param store and conditions to their own envelope

### DIFF
--- a/protos/config_specs.proto
+++ b/protos/config_specs.proto
@@ -18,6 +18,9 @@ enum SpecsEnvelopeKind {
   SPECS_ENVELOPE_KIND_FEATURE_GATE = 3; // Spec
   SPECS_ENVELOPE_KIND_DYNAMIC_CONFIG = 4; // Spec
   SPECS_ENVELOPE_KIND_LAYER_CONFIG = 5; // Spec
+
+  SPECS_ENVELOPE_KIND_PARAM_STORE = 6; // ParamStore
+  SPECS_ENVELOPE_KIND_CONDITION = 7; // Condition
 }
 
 message SpecsTopLevel {
@@ -26,7 +29,6 @@ message SpecsTopLevel {
   string company_id = 3;
   string response_format = 4;
   string checksum = 5;
-  map<string, Condition> condition_map = 6;
   bytes rest = 7;
 }
 


### PR DESCRIPTION
Move these to their own envelope so we can skip them during deserialization like we do with Specs that we already have